### PR TITLE
Http headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ drydock.jsonRoute({
 
 Each handler function takes a request object.  This object will have the following properties:
 
+- `headers` - the headers of the HTTP request.
 - `payload` - the body of the HTTP request.
 - `params` - the parameters in the requested URL (see below).
 - `query` - the dictionary object equivalent of the query string.

--- a/src/node/routes/instance.js
+++ b/src/node/routes/instance.js
@@ -15,7 +15,7 @@ function getSelectedHandler (drydock, routeName) {
 
 function filterRequest (req) {
   return _.chain(req)
-    .pick("payload", "params", "query")
+    .pick("headers", "payload", "params", "query")
     .cloneDeep()
     .value();
 }


### PR DESCRIPTION
Adding headers from hapi to the request objects for use in Drymock as a part of TACo and story S116940.