### PR TITLE
Allow case insensitive routesgs

### DIFF
--- a/src/node/index.js
+++ b/src/node/index.js
@@ -88,7 +88,7 @@ export default class Drydock {
     if (this.verbose) {
       log(`starting drydock ${version} server on ${this.ip}:${this.port}...`);
     }
-    this.server = new Server();
+    this.server = new Server({ connections: { router: { isCaseSensitive: false } } });
 
     const options = {
       host: this.ip,


### PR DESCRIPTION
This PR allows for case insensitive route registration and lookup. 

This story accompanies [S124040](https://rally1.rallydev.com/#/33116095857d/detail/userstory/67453001612?fdp=true). The same route can be called as `/defects` or `/Defects` which adds a lot of overhead and duplication to the test setups.

![](http://i.giphy.com/XIqCQx02E1U9W.gif)
